### PR TITLE
Add chart intervals to local storage

### DIFF
--- a/client/src/routes/output-states/OutputStates.tsx
+++ b/client/src/routes/output-states/OutputStates.tsx
@@ -4,7 +4,9 @@ import StatesAccordion from "./components/StatesAccordion";
 import { startTransition, useEffect, useState } from "react";
 
 export default function OutputStates() {
-  const [chartInterval, setChartInterval] = useState("24");
+  const [chartInterval, setChartInterval] = useState(
+    localStorage.getItem("outputChartInterval") ?? "24",
+  );
   const [segmentedControlValue, setSegmentedControlValue] =
     useState(chartInterval);
   const [chartRendering, setChartRendering] = useState(true);
@@ -27,6 +29,7 @@ export default function OutputStates() {
               defaultValue={segmentedControlValue}
               value={segmentedControlValue}
               onChange={(value) => {
+                localStorage.setItem("outputChartInterval", value);
                 setSegmentedControlValue(value);
                 setChartRendering(true);
                 startTransition(() => {

--- a/client/src/routes/sensor-data/SensorData.tsx
+++ b/client/src/routes/sensor-data/SensorData.tsx
@@ -14,7 +14,9 @@ import SensorTable from "./components/SensorTable";
 export default function SensorData() {
   const readingTypeString = useLoaderData() as string;
 
-  const [chartInterval, setChartInterval] = useState("24");
+  const [chartInterval, setChartInterval] = useState(
+    localStorage.getItem("sensorChartInterval") ?? "24",
+  );
   const [segmentedControlValue, setSegmentedControlValue] =
     useState(chartInterval);
   const [chartRendering, setChartRendering] = useState(true);
@@ -43,6 +45,7 @@ export default function SensorData() {
             defaultValue={segmentedControlValue}
             value={segmentedControlValue}
             onChange={(value) => {
+              localStorage.setItem("sensorChartInterval", value);
               setSegmentedControlValue(value);
               setChartRendering(true);
               startTransition(() => {


### PR DESCRIPTION
This update adds chart intervals to local storage so that when the page gets reloaded the chart intervals will be remembered.