### PR TITLE
Fix header text not changing on navigation

### DIFF
--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { Outlet, useLoaderData, useLocation } from "react-router-dom";
+import { Outlet, useLoaderData } from "react-router-dom";
 import { MantineProvider, AppShell } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 // All packages except `@mantine/hooks` require styles imports
@@ -12,22 +11,10 @@ import NavbarContents from "../shell/navbar/NavbarContents";
 import { ReadingType } from "@sproot/sproot-common/dist/sensors/ReadingType";
 
 export default function Root() {
-  const location = useLocation();
   const readingTypes = Object.keys(
     useLoaderData() as Partial<Record<ReadingType, string>>,
   ) as ReadingType[];
   const pages = Object.values(getNavbarItems(readingTypes));
-  const allPages = Object.values(getNavbarItems(readingTypes)).flatMap(
-    (page) => {
-      if (page.links) {
-        return [page, ...page.links];
-      }
-      return [page];
-    },
-  );
-  const [currentPage, setCurrentPage] = useState(
-    allPages.filter((page) => page.href === location.pathname)[0],
-  );
   const [isNavbarOpened, setIsNavbarOpened] = useDisclosure(false);
 
   function closeNavbar() {
@@ -49,16 +36,14 @@ export default function Root() {
       >
         <AppShell.Header>
           <HeaderContents
-            headerText={currentPage!.headerText}
             navbarToggle={setIsNavbarOpened.toggle}
             navbarOpened={isNavbarOpened}
           />
         </AppShell.Header>
         <AppShell.Navbar style={{ width: "250px", opacity: "95%" }} p="md">
           <NavbarContents
-            setCurrentPage={(view) => {
+            closeNavbar={() => {
               closeNavbar();
-              setCurrentPage(view);
             }}
             pages={pages}
           />

--- a/client/src/shell/navbar/NavbarContents.tsx
+++ b/client/src/shell/navbar/NavbarContents.tsx
@@ -6,12 +6,12 @@ import { Page } from "../Pages";
 import { useState } from "react";
 
 interface NavbarContentsProps {
-  setCurrentPage: (page: Page) => void;
+  closeNavbar: () => void;
   pages: Page[];
 }
 
 export default function NavbarContents({
-  setCurrentPage,
+  closeNavbar: closeNavbar,
   pages,
 }: NavbarContentsProps) {
   const [openedLinkGroups, setOpenedLinkGroups] = useState([] as string[]);
@@ -20,7 +20,7 @@ export default function NavbarContents({
       page={item}
       navLinkText={item.navLinkText}
       icon={item.icon}
-      setCurrentPage={setCurrentPage}
+      closeNavbar={closeNavbar}
       key={item.navLinkText}
       openedLinkGroups={openedLinkGroups}
       setOpenedLinkGroups={setOpenedLinkGroups}

--- a/client/src/shell/navbar/NavbarLinksGroup.tsx
+++ b/client/src/shell/navbar/NavbarLinksGroup.tsx
@@ -8,7 +8,7 @@ interface LinksGroupProps {
   icon: (props: TablerIconsProps | undefined) => JSX.Element;
   navLinkText: string;
   page: Page;
-  setCurrentPage: (page: Page) => void;
+  closeNavbar: () => void;
   openedLinkGroups: string[];
   setOpenedLinkGroups: (linkGroups: string[]) => void;
 }
@@ -17,7 +17,7 @@ export function LinksGroup({
   icon: Icon,
   navLinkText,
   page,
-  setCurrentPage,
+  closeNavbar: closeNavbar,
   openedLinkGroups,
   setOpenedLinkGroups,
 }: LinksGroupProps) {
@@ -29,7 +29,7 @@ export function LinksGroup({
       key={link.navLinkText}
       onClick={() => {
         setOpenedLinkGroups([]);
-        setCurrentPage(link);
+        closeNavbar();
       }}
     >
       {link.navLinkText}
@@ -52,7 +52,7 @@ export function LinksGroup({
           }
           if (!hasLinks) {
             setOpenedLinkGroups([]);
-            setCurrentPage(page);
+            closeNavbar();
           }
         }}
       >


### PR DESCRIPTION
This reworks how the headertext is updated. Previously it was done by setting state when someone clicks on the navbar. However, this doesn't update if someone uses the actual navigation in their browser. Now, it grabs the headertext by using the current page location and mapping it to the pages used for the navbar.