### PR TITLE
Give pin a default value of 0

### DIFF
--- a/client/src/routes/output-states/components/StatesChart.tsx
+++ b/client/src/routes/output-states/components/StatesChart.tsx
@@ -58,7 +58,7 @@ export default function StatesChart({
           withYAxis
           tickLine="xy"
           xAxisProps={{ dataKey: "name", interval: "equidistantPreserveStart" }}
-          yAxisProps={{ domain: [0, 100] }}
+          yAxisProps={{ type: "number", domain: [0, 100] }}
           // unit={unit}
           dataKey="outputName"
           series={chartSeries ?? []}

--- a/client/src/routes/sensor-data/components/ReadingsChart.tsx
+++ b/client/src/routes/sensor-data/components/ReadingsChart.tsx
@@ -62,7 +62,7 @@ export default function ReadingsChart({
           withYAxis
           tickLine="xy"
           xAxisProps={{ dataKey: "name", interval: "equidistantPreserveStart" }}
-          yAxisProps={{ domain: ["auto", "auto"] }}
+          yAxisProps={{ type: "number", domain: ["auto", "auto"] }}
           referenceLines={[
             {
               y: stats.cumulativeAverage!,

--- a/client/src/routes/settings/outputs/NewOutputModal.tsx
+++ b/client/src/routes/settings/outputs/NewOutputModal.tsx
@@ -41,11 +41,18 @@ export default function NewOutputModal({
   });
 
   const newOutputForm = useForm({
+    // Note - `mode: "uncontrolled"` prevents the form from rerendering every time a value in the form changes.
+    // If and when we get around to adding other output types (besides PCA9685), we'll probably want to set this
+    // and use some individual refs or states to keep track of things.
+    // https://mantine.dev/form/uncontrolled/
+
+    // mode: "uncontrolled",
     initialValues: {
       name: "",
       color: DefaultColors[Math.floor(Math.random() * DefaultColors.length)],
       model: supportedModels[0] ?? "",
       address: "",
+      pin: 0,
       isPwm: false,
       isInvertedPwm: false,
     } as FormValues,
@@ -67,6 +74,8 @@ export default function NewOutputModal({
         !value || (value.length > 0 && value.length <= 64)
           ? null
           : "Address must be between 1 and 64 characters",
+      pin: (value) =>
+        value != null && value != undefined ? null : "Must have a value",
       isPwm: (value) =>
         value === true || value === false ? null : "Must be true or false",
       isInvertedPwm: (value) =>

--- a/client/src/routes/settings/outputs/OutputSettings.tsx
+++ b/client/src/routes/settings/outputs/OutputSettings.tsx
@@ -15,9 +15,9 @@ export interface FormValues {
   color: string;
   model: string;
   address: string;
-  pin?: number;
-  isPwm?: boolean;
-  isInvertedPwm?: boolean;
+  pin: number;
+  isPwm: boolean;
+  isInvertedPwm: boolean;
   automationTimeout?: number;
 }
 


### PR DESCRIPTION
This may change in the future, as I can see some cases where outputs may not have an explicit "pin" (thinking on wifi plugs). However, other devices (like wifi power strips) may have multiple controls on them. IDK, right now, a default of 0 fixes things satisfactorily.