### PR TITLE
Increase phpmyadmin import size limit

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
       - 3001:80
     environment:
       - PMA_HOST=db
+      - UPLOAD_LIMIT=500M
 
 networks:
   sproot-network:

--- a/docker-compose.yaml.development
+++ b/docker-compose.yaml.development
@@ -69,6 +69,7 @@ services:
       - 3001:80
     environment:
       - PMA_HOST=db
+      - UPLOAD_LIMIT=500M
 
 networks:
   sproot-network:


### PR DESCRIPTION
This increases the size of a sql file you can import through the phpmyadmin interface. 2MB is a piddling amount - this ups it to a much more extravagant 500MB.