### PR TITLE
Make the Output States table locally orderable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,9 @@
     "vite": "^6.2.2"
   },
   "dependencies": {
+    "@dnd-kit/accessibility": "^3.1.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@mantine/charts": "^7.11.2",
     "@mantine/core": "^7.4.2",
     "@mantine/dates": "^7.12.2",

--- a/client/src/routes/output-states/components/SortableAccordionItem.tsx
+++ b/client/src/routes/output-states/components/SortableAccordionItem.tsx
@@ -1,0 +1,53 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { Accordion, Badge, Group } from "@mantine/core";
+import { IOutputBase } from "@sproot/outputs/IOutputBase";
+import StateCard from "./StateCard";
+import { CSS } from "@dnd-kit/utilities";
+import { IconGripVertical } from "@tabler/icons-react";
+
+interface SortableAccordionItemProps {
+  output: IOutputBase;
+  updateOutputsAsync: () => Promise<void>;
+}
+
+export default function SortableAccordionItem({
+  output,
+  updateOutputsAsync,
+}: SortableAccordionItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: output.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <Accordion.Item
+        key={output.id}
+        id={String(output.id)}
+        value={`item-${output.id}`}
+      >
+        <Accordion.Control>
+          <Group>
+            <div ref={setActivatorNodeRef} {...attributes} {...listeners}>
+              <IconGripVertical color={"lightgray"} />
+            </div>
+            <Badge size="xl" radius="sm" color={output.color}>
+              {output.name}
+            </Badge>
+          </Group>
+        </Accordion.Control>
+        <Accordion.Panel>
+          <StateCard output={output} updateOutputsAsync={updateOutputsAsync} />
+        </Accordion.Panel>
+      </Accordion.Item>
+    </div>
+  );
+}

--- a/client/src/routes/output-states/components/StatesAccordion.tsx
+++ b/client/src/routes/output-states/components/StatesAccordion.tsx
@@ -1,19 +1,63 @@
+import {
+  DndContext,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { IOutputBase } from "@sproot/sproot-common/src/outputs/IOutputBase";
-import { Accordion, Badge } from "@mantine/core";
-import StateCard from "./StateCard";
+import { Accordion } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { getOutputsAsync } from "@sproot/sproot-client/src/requests/requests_v2";
 import { useQuery } from "@tanstack/react-query";
+import SortableAccordionItem from "./SortableAccordionItem";
 
 export default function OutputAccordion() {
-  const [outputs, setOutputs] = useState({} as Record<string, IOutputBase>);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const [outputs, setOutputs] = useState([] as IOutputBase[]);
   const getOutputsQuery = useQuery({
     queryKey: ["output-states-accordion"],
     queryFn: () => getOutputsAsync(),
   });
 
   const updateOutputsAsync = async () => {
-    setOutputs((await getOutputsQuery.refetch()).data!);
+    const lastOutputStateOrder =
+      localStorage.getItem("outputStateOrder")?.split(",") ?? ([] as string[]);
+    const retrievedOutputs = Object.values(
+      (await getOutputsQuery.refetch()).data!,
+    );
+    const orderedOutputs: IOutputBase[] = [];
+
+    //Get outputs that don't exist in last list
+    const newOutputs = retrievedOutputs.filter(
+      (output) => !lastOutputStateOrder.includes(String(output.id)),
+    );
+
+    //Add the outputs that do exist in the last list
+    lastOutputStateOrder.forEach((outputId) => {
+      const outputIndex = retrievedOutputs.findIndex(
+        (o) => o.id == Number(outputId),
+      );
+      if (outputIndex != -1) {
+        orderedOutputs.push(retrievedOutputs[outputIndex]!);
+      }
+    });
+
+    //Add the new ones to the end of the order
+    setOutputs(orderedOutputs.concat(newOutputs));
   };
 
   useEffect(() => {
@@ -26,31 +70,47 @@ export default function OutputAccordion() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  let value = 0;
-  const items = Object.keys(outputs).map((key) => {
-    value++;
-    const output = outputs[key];
-    if (!output) {
-      return null;
-    }
-
-    return (
-      <Accordion.Item key={output.name} value={`item-${value}`}>
-        <Accordion.Control>
-          <Badge size="xl" radius="sm" color={output.color}>
-            {output.name}
-          </Badge>
-        </Accordion.Control>
-        <Accordion.Panel>
-          <StateCard output={output} updateOutputsAsync={updateOutputsAsync} />
-        </Accordion.Panel>
-      </Accordion.Item>
-    );
-  });
-
+  const items = Object.values(outputs);
+  const sortableItems = items.map((output) => (
+    <SortableAccordionItem
+      output={output}
+      updateOutputsAsync={updateOutputsAsync}
+    />
+  ));
   return getOutputsQuery.isPending ? (
     <p>Loading...</p>
   ) : (
-    <Accordion>{items}</Accordion>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <Accordion>
+        <SortableContext items={items} strategy={verticalListSortingStrategy}>
+          {sortableItems}
+        </SortableContext>
+      </Accordion>
+    </DndContext>
   );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (over == null) {
+      return;
+    }
+
+    if (active.id !== over?.id) {
+      setOutputs((items: IOutputBase[]) => {
+        const oldIndex = items.findIndex((output) => output.id == active.id);
+        const newIndex = items.findIndex((output) => output.id == over!.id);
+
+        const updatedArray = arrayMove(items, oldIndex, newIndex);
+        localStorage.setItem(
+          "outputStateOrder",
+          updatedArray.map((output) => output.id).toString(),
+        );
+        return updatedArray;
+      });
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,9 @@
     "client": {
       "name": "@sproot/sproot-client",
       "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@mantine/charts": "^7.11.2",
         "@mantine/core": "^7.4.2",
         "@mantine/dates": "^7.12.2",
@@ -533,6 +536,83 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.1",


### PR DESCRIPTION
This is a total convenience factor thing, but having this table be locally orderable is a good step in making it easier to handle larger lists of outputs. Not an issue if you've only got like 4, but it really tied you to the order you created your outputs in.

Now, you can reorder them however you see fit - it's local to your device, so it should persist and won't change someone else's layout.