### PR TITLE
Add sortability to the sensor table

### DIFF
--- a/client/src/routes/output-states/components/StatesAccordion.tsx
+++ b/client/src/routes/output-states/components/StatesAccordion.tsx
@@ -70,8 +70,7 @@ export default function OutputAccordion() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const items = Object.values(outputs);
-  const sortableItems = items.map((output) => (
+  const sortableItems = outputs.map((output) => (
     <SortableAccordionItem
       output={output}
       updateOutputsAsync={updateOutputsAsync}
@@ -86,7 +85,7 @@ export default function OutputAccordion() {
       onDragEnd={handleDragEnd}
     >
       <Accordion>
-        <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        <SortableContext items={outputs} strategy={verticalListSortingStrategy}>
           {sortableItems}
         </SortableContext>
       </Accordion>

--- a/client/src/routes/sensor-data/components/SortableTableRow.tsx
+++ b/client/src/routes/sensor-data/components/SortableTableRow.tsx
@@ -1,0 +1,71 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { Table, Flex, Switch } from "@mantine/core";
+import { ISensorBase } from "@sproot/sproot-common/src/sensors/ISensorBase";
+import { ReadingType } from "@sproot/sproot-common/src/sensors/ReadingType";
+import { convertCelsiusToFahrenheit } from "@sproot/sproot-common/src/utility/DisplayFormats";
+import { CSS } from "@dnd-kit/utilities";
+import { IconGripVertical } from "@tabler/icons-react";
+import { useTransition } from "react";
+
+interface SortableTableRowProps {
+  sensor: ISensorBase;
+  readingType: ReadingType;
+  useAlternateUnits: boolean;
+  toggleStates: string[];
+  setToggleState: (sensorNames: string[]) => void;
+}
+
+export default function SortableTableRow({
+  sensor,
+  readingType,
+  useAlternateUnits,
+  toggleStates,
+  setToggleState,
+}: SortableTableRowProps) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, startTransition] = useTransition();
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: sensor.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <Table.Tr ref={setNodeRef} style={style} key={sensor.id}>
+      <Table.Td ref={setActivatorNodeRef} {...attributes} {...listeners}>
+        <IconGripVertical color={"lightgray"} />
+      </Table.Td>
+      <Table.Td style={{ verticalAlign: "middle" }}>
+        <Flex style={{ alignContent: "center" }}>
+          <Switch
+            defaultChecked
+            color={sensor.color}
+            onChange={() => {
+              startTransition(() => {
+                if (toggleStates.includes(sensor.name)) {
+                  toggleStates.splice(toggleStates.indexOf(sensor.name), 1);
+                } else {
+                  toggleStates.push(sensor.name);
+                }
+                setToggleState([...toggleStates]);
+              });
+            }}
+          />
+        </Flex>
+      </Table.Td>
+      <Table.Td>{sensor.name}</Table.Td>
+      <Table.Td>
+        {useAlternateUnits && readingType == ReadingType.temperature
+          ? `${convertCelsiusToFahrenheit(sensor.lastReading[readingType])} °F`
+          : `${sensor.lastReading[readingType]} ${sensor.units[readingType]}`}
+      </Table.Td>
+    </Table.Tr>
+  );
+}


### PR DESCRIPTION
Like the output accordion, I could see this getting chaotic if you had a bunch of sensors and had no real way to organize them. This should also store the state of these things to local storage.

Hard to test because I only have a lot of thermometers, this should theoretically still keep track of other type of sensor arrangements as well. Doesn't look like anything broke at least.