### PR TITLE
Add env var for controlling debug logging

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ TZ: America/Los_Angeles
 NODE_ENV: production
 
 # Server configuration
+LOG_DEBUG: false #Set to true to enable debug logging
 DEFAULT_USER: dev-test #Change this to something unique
 DEFAULT_USER_EMAIL: dev-test@example.com 
 DEFAULT_USER_PASSWORD: password #Change this to something long and unique

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - TZ=${TZ}
       - NODE_ENV=${NODE_ENV}
+      - LOG_DEBUG=${LOG_DEBUG}
       - DEFAULT_USER=${DEFAULT_USER}
       - DEFAULT_USER_EMAIL=${DEFAULT_USER_EMAIL}
       - DEFAULT_USER_PASSWORD=${DEFAULT_USER_PASSWORD}

--- a/docker-compose.yaml.development
+++ b/docker-compose.yaml.development
@@ -8,6 +8,7 @@ services:
     environment:
       TZ: America/Los_Angeles
       NODE_ENV: development
+      LOG_DEBUG: true
       DEFAULT_USER: dev-test
       DEFAULT_USER_EMAIL: dev-test@example.com
       DEFAULT_USER_PASSWORD: password

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -38,7 +38,10 @@ export default function setupLogger(app: Express): winston.Logger {
     ],
   });
 
-  if (process.env["NODE_ENV"]?.toLowerCase() !== "production") {
+  if (
+    process.env["NODE_ENV"]?.toLowerCase() !== "production" ||
+    process.env["LOG_DEBUG"]?.toLowerCase() === "true"
+  ) {
     logger.add(
       new winston.transports.Console({
         level: "debug",
@@ -50,14 +53,16 @@ export default function setupLogger(app: Express): winston.Logger {
       }),
     );
     logger.add(
-      new winston.transports.File({
+      new winston.transports.DailyRotateFile({
         filename: "logs/debug.log",
-        level: "debug",
+        datePattern: "YYYY-MM-DD",
+        level: "debug-%DATE%.log",
         format: winston.format.combine(
           winston.format.errors({ stack: true }),
           winston.format.colorize(),
           winston.format.printf(formatForDebug),
         ),
+        maxFiles: "30d",
       }),
     );
     app.use(


### PR DESCRIPTION
Add a new env variable so I can easily add debug logs to a production instance